### PR TITLE
Added Option to Hide Share Options in a Post

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,15 @@ For responsive images you could use the built-in responsive image shortcode (wit
 {{%/* img-responsive "http://example.com/image.jpg" */%}}
 ```
 
+### Hide Share Options
+
+If you would like to hide the share options in the single post view, you can add this option in the `params` section of your config file.
+
+```toml
+[params]
+  <<other options>>
+  hideShareOptions = true
+```
+
 ### Screenshot
 ![Screenshot](http://i.imgur.com/Dsj41Rz.png)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you would like to hide the share options in the single post view, you can add
 
 ```toml
 [params]
-  <<other options>>
+  # ... other options ...
   hideShareOptions = true
 ```
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
                             {{ end }}
                         </p>
                     </header>
-
+                    {{ if not .Site.Params.hideShareOptions }}
                     <div class="post-share">
                         <div class="post-share-links">
                             <h4 style="">Share</h4>
@@ -36,6 +36,7 @@
                             
                         </div>
                     </div>
+                    {{ end }}
                     <div class="post-description">
                         {{ .Content }}
                     </div>


### PR DESCRIPTION
The change is pretty simple, it allows to set a Site Param to hide the share options in a post. 