### PR TITLE
Add optional Stack Overflow link to sidebar via site params

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ disqusShortname = "xxxx"
 [params]
   twitterName = "dragos_plesca"
   githubName = "dplesca"
+  stackOverflowId = "#######"
   description = "Demo site for a hugo theme"
   google_analytics = "UA-xxxxxx-xx"
 ```
 
-Notice the configuration necessary for disqus comments (just setting the disqusShortname), the twitter and github handlers (for the site sidebar), the site description and enabling Google Analytics reporting.
+Notice the configuration necessary for disqus comments (just setting the disqusShortname); the twitter, github, and stack overflow handlers (for the site sidebar); the site description and enabling Google Analytics reporting.
 
 ### Syntax Highlighting
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -17,6 +17,11 @@
                     <a class="pure-button" href="https://github.com/{{ . }} "><i class="fa fa-github-alt"></i> github</a>
                 </li>
                 {{ end }}
+                {{ with .Site.Params.stackOverflowId }}
+                <li class="nav-item">
+                    <a class="pure-button" href="https://stackoverflow.com/u/{{ . }} "><i class="fa fa-stack-overflow"></i> Stack Overflow</a>
+                </li>
+                {{ end }}
                 <li class="nav-item">
                     <a class="pure-button" href="{{ .Site.BaseURL }}/index.xml"><i class="fa fa-rss"></i> rss</a>
                 </li>


### PR DESCRIPTION
If a Stack Overflow ID is included in the site params, a link to the user's SO profile will be displayed in the sidebar. Uses the SO fontawesome icon.