### PR TITLE
 Add the option to hide text next to icons 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ disqusShortname = "xxxx"
   twitterName = "dragos_plesca"
   githubName = "dplesca"
   stackOverflowId = "#######"
+  linkedinName = "dragos-plesca-52797444"
   description = "Demo site for a hugo theme"
   google_analytics = "UA-xxxxxx-xx"
 ```
 
-Notice the configuration necessary for disqus comments (just setting the disqusShortname); the twitter, github, and stack overflow handlers (for the site sidebar); the site description and enabling Google Analytics reporting.
+Notice the configuration necessary for disqus comments (just setting the disqusShortname); the twitter, github, stack overflow and linkedin handlers (for the site sidebar); the site description and enabling Google Analytics reporting.
 
 ### Syntax Highlighting
 

--- a/README.md
+++ b/README.md
@@ -55,5 +55,16 @@ If you would like to hide the share options in the single post view, you can add
   hideShareOptions = true
 ```
 
+### Hide Sidebar icons text Options
+
+
+If you would like to hide the text next to the icons on the sidebar, you can add this option in the `params` section of your config file.
+
+```toml
+[params]
+  # ... other options ...
+  hideSidebarIconText = true
+```
+
 ### Screenshot
 ![Screenshot](http://i.imgur.com/Dsj41Rz.png)

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,28 +7,38 @@
 
         <nav class="nav">
             <ul class="nav-list">
-                {{ with .Site.Params.twitterName }}
+                {{ if .Site.Params.twitterName }}
                 <li class="nav-item">
-                    <a class="pure-button" href="https://twitter.com/{{ . }}"><i class="fa fa-twitter"></i> Twitter</a>
+                    <a class="pure-button" href="https://twitter.com/{{ .Site.Params.twitterName }}">
+                        <i class="fa fa-twitter"></i>{{ if not .Site.Params.hideSidebarIconText }} Twitter{{ end }}
+                    </a>
                 </li>
                 {{ end }}
-                {{ with .Site.Params.githubName }}
+                {{ if .Site.Params.githubName }}
                 <li class="nav-item">
-                    <a class="pure-button" href="https://github.com/{{ . }} "><i class="fa fa-github-alt"></i> github</a>
+                    <a class="pure-button" href="https://github.com/{{ .Site.Params.githubName }}">
+                        <i class="fa fa-github-alt"></i>{{ if not .Site.Params.hideSidebarIconText }} Github{{ end }}
+                    </a>
                 </li>
                 {{ end }}
-                {{ with .Site.Params.stackOverflowId }}
+                {{ if .Site.Params.stackOverflowId }}
                 <li class="nav-item">
-                    <a class="pure-button" href="https://stackoverflow.com/u/{{ . }} "><i class="fa fa-stack-overflow"></i> Stack Overflow</a>
+                    <a class="pure-button" href="https://stackoverflow.com/u/{{ .Site.Params.stackOverflowId }}">
+                        <i class="fa fa-stack-overflow"></i>{{ if not .Site.Params.hideSidebarIconText }}Stack Overflow{{ end }}
+                    </a>
                 </li>
                 {{ end }}
-                {{ with .Site.Params.linkedinName }}
+                {{ if .Site.Params.linkedinName }}
                 <li class="nav-item">
-                    <a class="pure-button" href="https://www.linkedin.com/in/{{ . }} "><i class="fa fa-linkedin"></i> LinkedIn</a>
+                    <a class="pure-button" href="https://www.linkedin.com/in/{{ .Site.Params.linkedinName }}">
+                        <i class="fa fa-linkedin"></i>{{ if not .Site.Params.hideSidebarIconText }} LinkedIn{{ end }}
+                    </a>
                 </li>
                 {{ end }}
                 <li class="nav-item">
-                    <a class="pure-button" href="{{ .Site.BaseURL }}/index.xml"><i class="fa fa-rss"></i> rss</a>
+                    <a class="pure-button" href="{{ .Site.BaseURL }}/index.xml">
+                        <i class="fa fa-rss"></i>{{ if not .Site.Params.hideSidebarIconText }} rss{{ end }}
+                    </a>
                 </li>
             </ul>
         </nav>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -22,6 +22,11 @@
                     <a class="pure-button" href="https://stackoverflow.com/u/{{ . }} "><i class="fa fa-stack-overflow"></i> Stack Overflow</a>
                 </li>
                 {{ end }}
+                {{ with .Site.Params.linkedinName }}
+                <li class="nav-item">
+                    <a class="pure-button" href="https://www.linkedin.com/in/{{ . }} "><i class="fa fa-linkedin"></i> LinkedIn</a>
+                </li>
+                {{ end }}
                 <li class="nav-item">
                     <a class="pure-button" href="{{ .Site.BaseURL }}/index.xml"><i class="fa fa-rss"></i> rss</a>
                 </li>


### PR DESCRIPTION
This commit aims to be able to enable/disable the text next to the icons
on the sidebar. So one can either display icon + text or simply icon.