### PR TITLE
Normalize baseUrl paths

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,8 +20,9 @@
                             {{ end }}
                             {{ if isset .Params "categories" }}
                                 under 
-                                {{ $baseUrl := .Site.BaseURL }}
-                                {{ range .Params.categories }}<a class="post-category post-category-{{ . }}" href="{{ $baseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
+                                {{ range .Params.categories }}
+                                    <a class="post-category post-category-{{ . }}" href='{{ ( printf "categories/%s" . ) | absURL }}'>{{ . }}</a>
+                                {{ end }}
                             {{ end }}
                         </p>
                     </header>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,8 +19,9 @@
                             {{ end }}
                             {{ if isset .Params "categories" }}
                                 under 
-                                {{ $baseUrl := .Site.BaseURL }}
-                                {{ range .Params.categories }}<a class="post-category post-category-{{ . }}" href="{{ $baseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
+                                {{ range .Params.categories }}
+                                    <a class="post-category post-category-{{ . }}" href='{{ ( printf "categories/%s" . ) | absURL }}'>{{ . }}</a>
+                                {{ end }}
                             {{ end }}
                         </p>
                     </header>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,8 +20,7 @@
                             {{ end }}
                             {{ if isset .Params "categories" }}
                                 under 
-                                {{ $baseUrl := .Site.BaseURL }}
-                                {{ range .Params.categories }}<a class="post-category post-category-{{ . }}" href="{{ $baseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
+                                {{ range .Params.categories }}<a class="post-category post-category-{{ . }}" href='{{ ( printf "categories/%s" . ) | absURL }}'>{{ . }}</a>{{ end }}
                             {{ end }}
                         </p>
                     </header>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,4 +5,4 @@
         </ul>
     </div>
 </div>
-<script src="{{ .Site.BaseURL }}/js/all.min.js"></script>
+<script src='{{ "js/all.min.js" | absURL }}'></script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,9 +21,9 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css">
 
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/all.min.css">
+    <link rel="stylesheet" href='{{ "css/all.min.css" | absURL }}'>
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
 
-    <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}/index.xml" />
+    <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href='{{ "index.xml" | absURL }}' />
 </head>
 <body>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -36,7 +36,7 @@
                 </li>
                 {{ end }}
                 <li class="nav-item">
-                    <a class="pure-button" href="{{ .Site.BaseURL }}/index.xml">
+                    <a class="pure-button" href='{{ "index.xml" | absURL }}'>
                         <i class="fa fa-rss"></i>{{ if not .Site.Params.hideSidebarIconText }} rss{{ end }}
                     </a>
                 </li>


### PR DESCRIPTION
Use hugo's built-in absURL function to produce correctly formatted absolute URLs instead of manually concatenating separators.

This is mostly an aesthetic change as browsers correctly understood the malformed URLs for the most part. Before, the template would produce URLs such as:

- `<a class="pure-button" href="http://localhost:1313//index.xml">[...]</a>`
- `<a class="post-category post-category-open source" href="http://localhost:1313//categories/open-source">open source</a>`

(note the double slash after the port number).

It seems as though hugo's `.Site.BaseURL` already contains a trailing slash, which would double up when building a path using e.g. `{{ .Site.BaseURL }}/categories/{{ . | urlize }}`.

This fix uses hugo's built-in [`absURL`](https://gohugo.io/functions/absurl/) and [`printf`](https://gohugo.io/functions/printf/) functions to build correctly delimited absolute URLs for various links and resources, producing URLs such as:

- - `<a class="pure-button" href="http://localhost:1313/index.xml">[...]</a>`
- `<a class="post-category post-category-open source" href="http://localhost:1313/categories/open-source">open source</a>`

(note the single slash after the port number).