### PR TITLE
Clarify how to enable syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ Notice the configuration necessary for disqus comments (just setting the disqusS
 
 ### Syntax Highlighting
 
-Syntax highlighting is enabled by default and it uses the nice [rainbow js](http://craig.is/making/rainbows) library. All you need to do is to let rainbow.js the language of the highlighted code, using something like ````go` when writing the code in markdown.
+Syntax highlighting is enabled by default and uses the [Rainbow](http://craig.is/making/rainbows) highlighting library. All you need to do is add a language identifier to a code block.
+
+For example, to apply Go syntax highlighting in Markdown:
+
+    ```go
+        package main
+
+        import "fmt"
+
+        func main() {
+          fmt.Println("Hello, 世界")
+        }
+    ```
 
 ### Reponsive Images
 


### PR DESCRIPTION
Rephrase and correct missing word, and provide a full example of applying Go syntax highlighting to a Markdown code block.

Previously, the phrasing was:

> All you need to do is to let rainbow.js the language of the highlighted code

I think that should have read

> All you need to do is to let rainbow.js **know** the language of the highlighted code

but I rephrased it a bit to simplify the written instructions and then provided a full example using a Go code sample.

I just grabbed the sample off [the Go homepage](https://golang.org/), let me know if there's a different code sample we could use instead.