### PR TITLE
Fix deprecate variable

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
 
     <meta name="description" content="{{ if .IsNode }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ else }}{{ with .Description }}{{ . }}{{ end }}{{ end }}">
 
-    {{.Hugo.Generator}}
+    {{hugo.Generator}}
     <meta name="twitter:card" content="summary">
     {{ with .Site.Params.twitter }}<meta name="twitter:site" content="{{ . }}" />{{ end }}
     <meta name="twitter:title" content="{{ .Title }} &middot; {{ .Site.Title }}">


### PR DESCRIPTION
Reason: https://gohugo.io/variables/hugo/

> Page’s .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
> For example: hugo.Generator.

hugo command reports warning, so fixed it.