### PR TITLE
Minimal i18n support

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,2 @@
+powered:
+  other: 'Built with <a class="hugo" href="https://gohugo.io/" target="_blank">hugo</a>'

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,0 +1,2 @@
+powered:
+  other: 'Réalisé avec <a class="hugo" href="https://gohugo.io/" target="_blank">hugo</a>'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,8 +7,8 @@
         <div>
             <!-- A wrapper for all the blog posts -->
             <div class="posts">
-                {{ range .Paginator.Pages }}
-                <h1 class="content-subhead">{{ .Date.Format "02 Jan 2006, 15:04" }}</h1>
+              {{ range .Paginator.Pages }}
+                <h1 class="content-subhead">{{ .Date | time.Format ":date_full" }}</h1>
                 <section class="post">
                     <header class="post-header">
 
@@ -29,7 +29,7 @@
                         {{ .Content }}
                     </div>
                 </section>
-                {{ end }}
+              {{ end }}
             </div>
             {{ partial "pagination.html" . }}
             {{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <div class="footer">
     <div class="pure-menu pure-menu-horizontal pure-menu-open">
         <ul>
-            <li>Powered by <a class="hugo" href="https://gohugo.io/" target="_blank">hugo</a></li>
+          <li>{{ i18n "powered" | safeHTML }}</li>
         </ul>
     </div>
 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ site.LanguageCode | default "en" }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -1,0 +1,11 @@
+{{ if .IsTranslated }}
+<nav class="i18n">
+  <ul>
+    {{ range .Translations }}
+    <li class="nav-item">
+      <a class="pure-button" href="{{ .RelPermalink }}">{{ .Lang }}</a>
+    </li>
+    {{ end}}
+  </ul>
+</nav>
+{{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,10 +1,11 @@
 <div class="sidebar pure-u-1 pure-u-md-1-4">
     <div class="header">
         <hgroup>
-            <h1 class="brand-title"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
+            <h1 class="brand-title"><a href="{{ absLangURL "" }}">{{ .Site.Title }}</a></h1>
             <h2 class="brand-tagline">{{ with .Site.Params.description }} {{.}} {{end}}</h2>
         </hgroup>
 
+        {{ partial "i18nlist.html" . }}
         <nav class="nav">
             <ul class="nav-list">
                 {{ if .Site.Params.twitterName }}


### PR DESCRIPTION
Corrects the main page link, the language ID in the header, and the date/time to be internationalized.
Adds a list of translations to the sidebar.
Also adds i18n to the "powered by" link (but needs a translation...)